### PR TITLE
Support for building wheel and images during CI.

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -1,0 +1,20 @@
+name: Build docker images
+
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main, dev ]
+  pull_request:
+    branches: [ main, dev ]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build_docker_images:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build images
+        run: |
+           bash ./deploy/scripts/build_images.sh

--- a/.github/workflows/build_whl.yml
+++ b/.github/workflows/build_whl.yml
@@ -1,6 +1,4 @@
-# federated learning CI workflow
-
-name: FL-CI
+name: Build wheel packages 
 
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
@@ -12,10 +10,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  tox_ci_test:
+  build_whl:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Python Env
         uses: actions/setup-python@v3
         with:
@@ -25,16 +24,13 @@ jobs:
         run: |
            curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/3.5.0/bazel-3.5.0-installer-linux-x86_64.sh && chmod +x bazel-*.sh && sudo ./bazel-3.5.0-installer-linux-x86_64.sh
 
-      - name: Install ci dependencies
+      - name: Build wheel packages
         run: |
-          python -m pip install --upgrade pip
-          pip install flake8 pytest tox
+           pwd && ls ./
+           source deploy/scripts/const.properties
+           bazel build $client_bazel_obj $sdk_bazel_obj $coordinator_bazel_obj $job_scheduler_bazel_obj $cli_bazel_obj $selector_bazel_obj
 
-      - name: Check dependencies install success
+      - name: Check wheel packages
         run: |
-          python -V
-          bazel --version
-          tox --version
-
-      - name: Run tox
-        run: tox
+           source deploy/scripts/const.properties
+           python3.7 -m pip install --upgrade --disable-pip-version-check $client_whl $sdk_whl $coordinator_whl $job_scheduler_whl $cli_whl $selector_whl

--- a/tox.ini
+++ b/tox.ini
@@ -24,9 +24,7 @@ commands =
     find . -type f -name "*.pyc" -delete
     bash {toxinidir}/deploy/scripts/build_proto.sh
     bazel clean
-    bash -c 'bazel build $client_bazel_obj $sdk_bazel_obj $coordinator_bazel_obj $job_scheduler_bazel_obj $cli_bazel_obj $selector_bazel_obj'
-    bash -c 'python3.7 -m pip uninstall --disable-pip-version-check -y $client_whl $sdk_whl $coordinator_whl $job_scheduler_whl $cli_whl $selector_whl'
-    bash -c 'python3.7 -m pip install --upgrade --disable-pip-version-check $client_whl $sdk_whl $coordinator_whl $job_scheduler_whl $cli_whl $selector_whl'
+    python3.7 -m pip install -r requirements.txt
     pylint --reports=n -f colorized --jobs=1 {toxinidir}/neursafe_fl
     flake8 --statistics --count --benchmark {toxinidir}/neursafe_fl --exclude={toxinidir}/.tox,{toxinidir}/neursafe_fl/proto/
     bash -c 'py.test --cov={toxinidir}/neursafe_fl -q -s {toxinidir}/neursafe_fl; ret=$?; if [ "$ret" = 5 ]; then exit 0; else exit "$ret"; fi'


### PR DESCRIPTION
1. Add tow CI jobs to build wheel and image.
2. The dev branch CI is added to meet the needs of this scenario: in the process of implementing a task on a dev branch, before merging to the master branch, there may be multiple commits, and these commits need to be verified on the dev branch. Instead of checking directly on the master branch.

Signed-off-by: lin.wen <wen.lin2@zte.com.cn>