### PR TITLE
Fix CI bug

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -3,9 +3,9 @@ name: Build docker images
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main, dev ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main ]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/build_whl.yml
+++ b/.github/workflows/build_whl.yml
@@ -3,9 +3,9 @@ name: Build wheel packages
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main, dev ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main ]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ name: FL-CI
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main, dev ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main ]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/neursafe_fl/python/client/test_storage_manager.py
+++ b/neursafe_fl/python/client/test_storage_manager.py
@@ -311,8 +311,11 @@ def create_sub_tree(base_path):
         os.makedirs(path)
 
     def create_file(path):
-        with open(path, 'w') as file:
-            file.write('test')
+        try:
+            with open(path, 'w') as file:
+                file.write('test')
+        except FileNotFoundError as err:
+            logging.exception(str(err))
 
     create_dir(join(base_path, 'dir1/dir2'))
     create_file(join(base_path, 'file1'))


### PR DESCRIPTION
There are two concurrent execution flow in the test case.
Flow 1 is constantly creating files /dirxx/filexx.
Flow 2 found that the storage exceeded the threshold and cleared /dirxx.
And Flow 1 does not consider it.

Signed-off-by: lin.wen <wen.lin2@zte.com.cn>