### PR TITLE
It should except ProxyError when create coordinator

### DIFF
--- a/neursafe_fl/python/job_scheduler/job.py
+++ b/neursafe_fl/python/job_scheduler/job.py
@@ -380,8 +380,8 @@ class Job:
             yield self.__do_create_coordinator()
 
             yield self.__wait_coordinator_running()
-        except (errors.CheckpointNotExist, errors.NoEnoughClientsResource) \
-                as err:
+        except (errors.CheckpointNotExist, errors.NoEnoughClientsResource,
+                ProxyError) as err:
             logging.error(str(err))
             self.__update_status({"state": State.FAILED,
                                   "reason": str(err)})


### PR DESCRIPTION
It should except ProxyError when create coordinator. because it maybe rasie ProxyError when do_create_proxy_route()

Signed-off-by: 唐超斌 10191406 <tang.chaobin@zte.com.cn>