### PR TITLE
Optimize performance of selective masking

### DIFF
--- a/neursafe_fl/python/libs/compression/selective_masking.py
+++ b/neursafe_fl/python/libs/compression/selective_masking.py
@@ -56,8 +56,7 @@ class SelectiveMasking(Compression):
         abs_value_ = np.abs(value_)
         top_k_length = int(self.top_k_ratio * value_.size)
 
-        top_k_ind = np.sort(
-            np.argpartition(abs_value_, -top_k_length)[-top_k_length:])
+        top_k_ind = np.argpartition(abs_value_, -top_k_length)[-top_k_length:]
 
         masked_value = value_[top_k_ind]
 
@@ -75,8 +74,7 @@ class SelectiveMasking(Compression):
             shape: the shape of raw numpy array(uncompressed array).
         """
         raw_value = np.zeros(np.prod(shape))
-        raw_value[ind] = 1
 
-        np.place(raw_value, raw_value == 1, masked_value)
+        np.put(raw_value, ind, masked_value)
 
         return np.reshape(raw_value, shape)

--- a/neursafe_fl/python/libs/compression/test_selectivemasking.py
+++ b/neursafe_fl/python/libs/compression/test_selectivemasking.py
@@ -34,6 +34,8 @@ class TestSelectiveMasking(unittest.TestCase):
 
         masked_value, params = compression.encode(self.value)
 
+        value = compression.decode(masked_value, **params)
+
         self.assertEqual(np.sort(masked_value)[::-1].tolist(),
                          np.sort(self.value.flatten())[::-1][:6].tolist())
 
@@ -41,8 +43,6 @@ class TestSelectiveMasking(unittest.TestCase):
         self.assertEqual(params["ind"].sort(),
                          self.value.flatten().argsort()[-6:].tolist().sort())
         self.assertEqual(len(params["ind"]), 6)
-
-        value = compression.decode(masked_value, **params)
 
         self.assertEqual(np.sort(value.flatten())[::-1][:6].tolist(),
                          np.sort(self.value.flatten())[::-1][:6].tolist())


### PR DESCRIPTION
1.Delete process of indexes sorting.

Signed-off-by: ChengMingZhang-ZTE <zhang.chengming30@zte.com.cn>