### PR TITLE
fix dir name of saving checkpoint

### DIFF
--- a/neursafe_fl/python/coordinator/common/workspace.py
+++ b/neursafe_fl/python/coordinator/common/workspace.py
@@ -52,6 +52,7 @@ class Workspace:
         self.__job_name = job_name
         self.__job_dir = None
         self.__tmp_dir = None
+        self.__job_v = 0
         self.__ckpt_root_dir = None
 
     def get_checkpoints(self):
@@ -160,21 +161,23 @@ class Workspace:
         if not self.__ckpt_root_dir:
             self.__ckpt_root_dir = self.__create_ckpt_root_dir()
 
+        name = "V%s_%s%s" % (self.__job_v, CHECKPOINT_FILE_PREFIX, ckpt_id)
         ckpt_dir = os.path.join(self.__output_dir,
                                 self.__job_dir,
                                 CKPT_ROOT_PATH,
-                                "%s%s" % (CHECKPOINT_FILE_PREFIX, ckpt_id))
+                                name)
 
         if not os.path.exists(ckpt_dir):
             os.mkdir(ckpt_dir)
 
-        return "%s%s" % (CHECKPOINT_FILE_PREFIX, ckpt_id), ckpt_dir
+        return name, ckpt_dir
 
     def _create_job_dir(self, version=0):
         job_dir = os.path.join(self.__output_dir,
                                "fl_%s_output_V%s" % (self.__job_name, version))
         if os.path.exists(job_dir):
             return self._create_job_dir(version=version + 1)
+        self.__job_v = version
         os.mkdir(job_dir)
         return job_dir
 

--- a/neursafe_fl/python/coordinator/trainer.py
+++ b/neursafe_fl/python/coordinator/trainer.py
@@ -124,8 +124,7 @@ class Trainer:
         self.finish()
 
     def __restore_checkpoints(self):
-        self.__checkpoints, max_ckpt_id = self.__workspace.get_checkpoints()
-        self.__next_ckpt_id = max_ckpt_id + 1
+        self.__checkpoints, _ = self.__workspace.get_checkpoints()
 
     def stop(self):
         """Stop the main process of job."""
@@ -378,9 +377,8 @@ class Trainer:
         ckpt_dir_name, ckpt_out_path = self.__workspace.create_ckpt_dir(
             self.__next_ckpt_id)
 
-        ckpt_filename = self.__workspace.get_runtime_file_by(Files.Checkpoint,
-                                                             self.__runtime,
-                                                             self.__round_id)
+        ckpt_filename = self.__workspace.get_runtime_file_by(
+            Files.Checkpoint, self.__runtime, "round%s" % self.__round_id)
         ckpt_file = join(ckpt_out_path, ckpt_filename)
 
         self.__fl_model.save_model(ckpt_file)


### PR DESCRIPTION
Signed-off-by: kewen.wang <wang.kewen@zte.com.cn>
Fix directory name of checkpoinks when saved.
/job_name_V1/checkpoints/V1__checkpoint_v0/checkpoint_round5.pth
V1 means the version of current job.
v0 means the  which number of checkpoint during this job execution.
round5 means save the checkpoint in round 5.